### PR TITLE
Fix warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Angular Date Time Picker",
   "keywords": [
     "Angular",

--- a/projects/picker/package.json
+++ b/projects/picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Angular Date Time Picker",
   "keywords": [
     "Angular",

--- a/projects/picker/src/lib/date-time/adapter/moment-adapter/moment-date-time-adapter.class.ts
+++ b/projects/picker/src/lib/date-time/adapter/moment-adapter/moment-date-time-adapter.class.ts
@@ -3,8 +3,8 @@
  */
 
 import { Inject, Injectable, Optional, InjectionToken } from '@angular/core';
-import * as _moment from 'moment/moment';
-import { Moment } from 'moment/moment';
+import * as _moment from 'moment';
+import { Moment } from 'moment';
 import { DateTimeAdapter, OWL_DATE_TIME_LOCALE } from '../date-time-adapter.class';
 
 const moment = (_moment as any).default ? (_moment as any).default : _moment;


### PR DESCRIPTION
The following moment warning appeared for a user:

> WARNING in Entry point '@danielmoncada/angular-datetime-picker' contains deep imports into 'C:/Users/jcomp/git/servoy_ngclient2/servoyeclipse/com.servoy.eclipse.ngclient.ui/node/node_modules/moment/moment'. This is probably not a problem, but may cause the compilation of entry points to be out of order.

- Update to not provide a deep import. used '/moment' instead of '/moment/moment'