### PR TITLE
Restore original LICENSE merging commit 61e7937 updating year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License
 
-Copyright (c) 2014-2016 Daniel Moncada.
+Copyright (c) 2014-2016 Daniel YK Pan.
+Copyright (c) 2020 Daniel Moncada.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The original copyright notice seems to have been replaced although the license explicitly required it to be included in all copies or substantial portions of the Software. This PR restores the original copyright notice and merges 61e7937 and updates year to 2020.