### PR TITLE
Fix immediate leading zero issue on time input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@danielmoncada/angular-datetime-picker",
-    "version": "9.4.2",
+    "version": "9.4.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Angular Date Time Picker",
   "keywords": [
     "Angular",

--- a/projects/picker/package.json
+++ b/projects/picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Angular Date Time Picker",
   "keywords": [
     "Angular",

--- a/projects/picker/src/lib/date-time/timer-box.component.html
+++ b/projects/picker/src/lib/date-time/timer-box.component.html
@@ -22,7 +22,9 @@
            [value]="displayValue | numberFixedLen : 2"
            (keydown.arrowup)="!upBtnDisabled && upBtnClicked()"
            (keydown.arrowdown)="!downBtnDisabled && downBtnClicked()"
-           (input)="handleInputChange(valueInput.value)" #valueInput>
+           (input)="handleInputChange(valueInput.value)" 
+           (focusout)="focusOut(valueInput.value)"
+           #valueInput>
     <span class="owl-hidden-accessible">{{inputLabel}}</span>
 </label>
 <button class="owl-dt-control-button owl-dt-control-arrow-button"

--- a/projects/picker/src/lib/date-time/timer-box.component.ts
+++ b/projects/picker/src/lib/date-time/timer-box.component.ts
@@ -82,7 +82,7 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
 
     public ngOnInit() {
         this.inputStreamSub = this.inputStream.pipe(
-            debounceTime(1),
+            debounceTime(500),
             distinctUntilChanged()
         ).subscribe(( val: string ) => {
             if (val) {
@@ -106,8 +106,15 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
         this.updateValue(this.value - this.step);
     }
 
-    public handleInputChange( val: string ): void {
+    public handleInputChange(val: string ): void {
         this.inputStream.next(val);
+    }
+
+    public focusOut(value: string): void {
+        if (value) {
+            const inputValue = coerceNumberProperty(value, 0);
+            this.updateValueViaInput(inputValue);
+        }
     }
 
     private updateValue( value: number ): void {


### PR DESCRIPTION
- add debounce back to allow for quick 2-digit time input. 
- add focus out event for immediate setting of time when pressing 'SET' within the initial debounce time.
- version update