### PR TITLE
Add UnixTimestampDateTimeAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ There are two pre-made modules, users need to import one of them or build your o
 
 - `OwlNativeDateTimeModule` - support for native JavaScript Date object
 - `OwlMomentDateTimeModule` - support for MomentJs
+- `OwlUnixTimestampDateTimeModule` - support for milliseconds since Epoch (number)
 
 Properties for `owl-date-time`
 -------

--- a/projects/picker/src/lib/date-time/adapter/unix-timestamp-adapter/unix-timestamp-date-time-adapter.class.ts
+++ b/projects/picker/src/lib/date-time/adapter/unix-timestamp-adapter/unix-timestamp-date-time-adapter.class.ts
@@ -1,0 +1,323 @@
+/**
+ * unix-timestamp-date-time-adapter.class
+ */
+
+import {Inject, Injectable, Optional} from '@angular/core';
+import {DateTimeAdapter, OWL_DATE_TIME_LOCALE} from '../date-time-adapter.class';
+import {Platform} from '@angular/cdk/platform';
+import {range} from '../../../utils/array.utils';
+import {createDate, getNumDaysInMonth} from '../../../utils/date.utils';
+import {DEFAULT_DATE_NAMES, DEFAULT_DAY_OF_WEEK_NAMES, DEFAULT_MONTH_NAMES, SUPPORTS_INTL_API} from '../../../utils/constants';
+
+@Injectable()
+export class UnixTimestampDateTimeAdapter extends DateTimeAdapter<number> {
+
+    constructor(
+        @Optional()
+        @Inject(OWL_DATE_TIME_LOCALE)
+        private owlDateTimeLocale: string,
+        platform: Platform
+    ) {
+        super();
+        super.setLocale(owlDateTimeLocale);
+
+        // IE does its own time zone correction, so we disable this on IE.
+        this.useUtcForDisplay = !platform.TRIDENT;
+        this._clampDate = platform.TRIDENT || platform.EDGE;
+    }
+
+    /** Whether to clamp the date between 1 and 9999 to avoid IE and Edge errors. */
+    private readonly _clampDate: boolean;
+
+    /**
+     * Whether to use `timeZone: 'utc'` with `Intl.DateTimeFormat` when formatting dates.
+     * Without this `Intl.DateTimeFormat` sometimes chooses the wrong timeZone, which can throw off
+     * the result. (e.g. in the en-US locale `new Date(1800, 7, 14).toLocaleDateString()`
+     * will produce `'8/13/1800'`.
+     */
+    useUtcForDisplay: boolean;
+
+    /**
+     * Strip out unicode LTR and RTL characters. Edge and IE insert these into formatted dates while
+     * other browsers do not. We remove them to make output consistent and because they interfere with
+     * date parsing.
+     */
+    private static stripDirectionalityCharacters(str: string) {
+        return str.replace(/[\u200e\u200f]/g, '');
+    }
+
+    /**
+     * When converting Date object to string, javascript built-in functions may return wrong
+     * results because it applies its internal DST rules. The DST rules around the world change
+     * very frequently, and the current valid rule is not always valid in previous years though.
+     * We work around this problem building a new Date object which has its internal UTC
+     * representation with the local date and time.
+     */
+    private static _format(dtf: Intl.DateTimeFormat, date: Date) {
+        const d = new Date(
+            Date.UTC(
+                date.getFullYear(),
+                date.getMonth(),
+                date.getDate(),
+                date.getHours(),
+                date.getMinutes(),
+                date.getSeconds(),
+                date.getMilliseconds()
+            )
+        );
+        return dtf.format(d);
+    }
+
+    addCalendarDays(date: number, amount: number): number {
+        const result = new Date(date);
+        amount = Number(amount);
+        result.setDate(result.getDate() + amount);
+        return result.getTime();
+    }
+
+    addCalendarMonths(date: number, amount: number): number {
+        const result = new Date(date);
+        amount = Number(amount);
+
+        const desiredMonth = result.getMonth() + amount;
+        const dateWithDesiredMonth = new Date(0);
+        dateWithDesiredMonth.setFullYear(result.getFullYear(), desiredMonth, 1);
+        dateWithDesiredMonth.setHours(0, 0, 0, 0);
+
+        const daysInMonth = this.getNumDaysInMonth(dateWithDesiredMonth.getTime());
+        // Set the last day of the new month
+        // if the original date was the last day of the longer month
+        result.setMonth(desiredMonth, Math.min(daysInMonth, result.getDate()));
+        return result.getTime();
+    }
+
+    addCalendarYears(date: number, amount: number): number {
+        return this.addCalendarMonths(date, amount * 12);
+    }
+
+    clone(date: number): number {
+        return date;
+    }
+
+    public createDate(
+        year: number,
+        month: number,
+        date: number,
+        hours: number = 0,
+        minutes: number = 0,
+        seconds: number = 0
+    ): number {
+        return createDate(year, month, date, hours, minutes, seconds).getTime();
+    }
+
+    differenceInCalendarDays(dateLeft: number, dateRight: number): number {
+        if (this.isValid(dateLeft) && this.isValid(dateRight)) {
+            const dateLeftStartOfDay = this.createDate(
+                this.getYear(dateLeft),
+                this.getMonth(dateLeft),
+                this.getDate(dateLeft)
+            );
+            const dateRightStartOfDay = this.createDate(
+                this.getYear(dateRight),
+                this.getMonth(dateRight),
+                this.getDate(dateRight)
+            );
+
+            const timeStampLeft =
+                this.getTime(dateLeftStartOfDay) -
+                new Date(dateLeftStartOfDay).getTimezoneOffset() *
+                this.milliseondsInMinute;
+            const timeStampRight =
+                this.getTime(dateRightStartOfDay) -
+                new Date(dateRightStartOfDay).getTimezoneOffset() *
+                this.milliseondsInMinute;
+            return Math.round(
+                (timeStampLeft - timeStampRight) / this.millisecondsInDay
+            );
+        } else {
+            return null;
+        }
+    }
+
+    format(date: number, displayFormat: any): string {
+        if (!this.isValid(date)) {
+            throw Error('JSNativeDate: Cannot format invalid date.');
+        }
+
+        const jsDate = new Date(date);
+
+        if (SUPPORTS_INTL_API) {
+            if (this._clampDate &&
+                (jsDate.getFullYear() < 1 || jsDate.getFullYear() > 9999)) {
+                jsDate.setFullYear(
+                    Math.max(1, Math.min(9999, jsDate.getFullYear()))
+                );
+            }
+
+            displayFormat = {...displayFormat, timeZone: 'utc'};
+            const dtf = new Intl.DateTimeFormat(this.locale, displayFormat);
+            return UnixTimestampDateTimeAdapter.stripDirectionalityCharacters(UnixTimestampDateTimeAdapter._format(dtf, jsDate));
+        }
+
+        return UnixTimestampDateTimeAdapter.stripDirectionalityCharacters(jsDate.toDateString());
+    }
+
+    getDate(date: number): number {
+        return new Date(date).getDate();
+    }
+
+    getDateNames(): string[] {
+        if (SUPPORTS_INTL_API) {
+            const dtf = new Intl.DateTimeFormat(this.locale, {
+                day: 'numeric',
+                timeZone: 'utc'
+            });
+            return range(31, i =>
+                UnixTimestampDateTimeAdapter.stripDirectionalityCharacters(
+                    UnixTimestampDateTimeAdapter._format(dtf, new Date(2017, 0, i + 1))
+                )
+            );
+        }
+        return DEFAULT_DATE_NAMES;
+    }
+
+    getDay(date: number): number {
+        return new Date(date).getDay();
+    }
+
+    getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
+        if (SUPPORTS_INTL_API) {
+            const dtf = new Intl.DateTimeFormat(this.locale, {
+                weekday: style,
+                timeZone: 'utc'
+            });
+            return range(7, i =>
+                UnixTimestampDateTimeAdapter.stripDirectionalityCharacters(
+                    UnixTimestampDateTimeAdapter._format(dtf, new Date(2017, 0, i + 1))
+                )
+            );
+        }
+
+        return DEFAULT_DAY_OF_WEEK_NAMES[style];
+    }
+
+    getHours(date: number): number {
+        return new Date(date).getHours();
+    }
+
+    getMinutes(date: number): number {
+        return new Date(date).getMinutes();
+    }
+
+    getMonth(date: number): number {
+        return new Date(date).getMonth();
+    }
+
+    getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
+        if (SUPPORTS_INTL_API) {
+            const dtf = new Intl.DateTimeFormat(this.locale, {
+                month: style,
+                timeZone: 'utc'
+            });
+            return range(12, i =>
+                UnixTimestampDateTimeAdapter.stripDirectionalityCharacters(
+                    UnixTimestampDateTimeAdapter._format(dtf, new Date(2017, i, 1))
+                )
+            );
+        }
+        return DEFAULT_MONTH_NAMES[style];
+    }
+
+    getNumDaysInMonth(date: number): number {
+        return getNumDaysInMonth(new Date(date));
+    }
+
+    getSeconds(date: number): number {
+        return new Date(date).getSeconds();
+    }
+
+    getTime(date: number): number {
+        return date;
+    }
+
+    getYear(date: number): number {
+        return new Date(date).getFullYear();
+    }
+
+    getYearName(date: number): string {
+        if (SUPPORTS_INTL_API) {
+            const dtf = new Intl.DateTimeFormat(this.locale, {
+                year: 'numeric',
+                timeZone: 'utc'
+            });
+            return UnixTimestampDateTimeAdapter.stripDirectionalityCharacters(UnixTimestampDateTimeAdapter._format(dtf, new Date(date)));
+        }
+        return String(this.getYear(date));
+    }
+
+    invalid(): number {
+        return NaN;
+    }
+
+    isDateInstance(obj: any): boolean {
+        return typeof obj === 'number';
+    }
+
+    isEqual(dateLeft: number, dateRight: number): boolean {
+        if (this.isValid(dateLeft) && this.isValid(dateRight)) {
+            return dateLeft === dateRight;
+        } else {
+            return false;
+        }
+    }
+
+    isSameDay(dateLeft: number, dateRight: number): boolean {
+        if (this.isValid(dateLeft) && this.isValid(dateRight)) {
+            const dateLeftStartOfDay = new Date(dateLeft);
+            const dateRightStartOfDay = new Date(dateRight);
+            dateLeftStartOfDay.setHours(0, 0, 0, 0);
+            dateRightStartOfDay.setHours(0, 0, 0, 0);
+            return (dateLeftStartOfDay.getTime() === dateRightStartOfDay.getTime());
+        } else {
+            return false;
+        }
+    }
+
+    isValid(date: number): boolean {
+        return (date || date === 0) && !isNaN(date);
+    }
+
+    now(): number {
+        return new Date().getTime();
+    }
+
+    parse(value: any, parseFormat: any): number | null {
+        // There is no way using the native JS Date to set the parse format or locale
+        if (typeof value === 'number') {
+            return value;
+        }
+        return value ? new Date(Date.parse(value)).getTime() : null;
+    }
+
+    setHours(date: number, amount: number): number {
+        const result = new Date(date);
+        result.setHours(amount);
+        return result.getTime();
+    }
+
+    setMinutes(date: number, amount: number): number {
+        const result = new Date(date);
+        result.setMinutes(amount);
+        return result.getTime();
+    }
+
+    setSeconds(date: number, amount: number): number {
+        const result = new Date(date);
+        result.setSeconds(amount);
+        return result.getTime();
+    }
+
+    toIso8601(date: number): string {
+        return new Date(date).toISOString();
+    }
+}

--- a/projects/picker/src/lib/date-time/adapter/unix-timestamp-adapter/unix-timestamp-date-time-format.class.ts
+++ b/projects/picker/src/lib/date-time/adapter/unix-timestamp-adapter/unix-timestamp-date-time-format.class.ts
@@ -1,0 +1,14 @@
+/**
+ * unix-timestamp-date-time-format.class
+ */
+import {OwlDateTimeFormats} from '../date-time-format.class';
+
+export const OWL_UNIX_TIMESTAMP_DATE_TIME_FORMATS: OwlDateTimeFormats = {
+    parseInput: null,
+    fullPickerInput: {year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric'},
+    datePickerInput: {year: 'numeric', month: 'numeric', day: 'numeric'},
+    timePickerInput: {hour: 'numeric', minute: 'numeric'},
+    monthYearLabel: {year: 'numeric', month: 'short'},
+    dateA11yLabel: {year: 'numeric', month: 'long', day: 'numeric'},
+    monthYearA11yLabel: {year: 'numeric', month: 'long'},
+};

--- a/projects/picker/src/lib/date-time/adapter/unix-timestamp-adapter/unix-timestamp-date-time.module.ts
+++ b/projects/picker/src/lib/date-time/adapter/unix-timestamp-adapter/unix-timestamp-date-time.module.ts
@@ -1,0 +1,26 @@
+/**
+ * unix-timestamp-date-time.module
+ */
+
+import {NgModule} from '@angular/core';
+import {PlatformModule} from '@angular/cdk/platform';
+import {DateTimeAdapter} from '../date-time-adapter.class';
+import {OWL_DATE_TIME_FORMATS} from '../date-time-format.class';
+import {UnixTimestampDateTimeAdapter} from './unix-timestamp-date-time-adapter.class';
+import {OWL_UNIX_TIMESTAMP_DATE_TIME_FORMATS} from './unix-timestamp-date-time-format.class';
+
+@NgModule({
+    imports: [PlatformModule],
+    providers: [
+        {provide: DateTimeAdapter, useClass: UnixTimestampDateTimeAdapter},
+    ],
+})
+export class UnixTimestampDateTimeModule {
+}
+
+@NgModule({
+    imports: [UnixTimestampDateTimeModule],
+    providers: [{provide: OWL_DATE_TIME_FORMATS, useValue: OWL_UNIX_TIMESTAMP_DATE_TIME_FORMATS}],
+})
+export class OwlUnixTimestampDateTimeModule {
+}

--- a/projects/picker/src/lib/utils/array.utils.ts
+++ b/projects/picker/src/lib/utils/array.utils.ts
@@ -1,0 +1,12 @@
+/**
+ * array.utils
+ */
+
+/** Creates an array and fills it with values. */
+export function range<T>(length: number, valueFunction: (index: number) => T): T[] {
+    const valuesArray = Array(length);
+    for (let i = 0; i < length; i++) {
+        valuesArray[i] = valueFunction(i);
+    }
+    return valuesArray;
+}

--- a/projects/picker/src/lib/utils/constants.ts
+++ b/projects/picker/src/lib/utils/constants.ts
@@ -1,0 +1,59 @@
+/**
+ * constants
+ */
+
+import {range} from './array.utils';
+
+/** Whether the browser supports the Intl API. */
+export const SUPPORTS_INTL_API = typeof Intl !== 'undefined';
+
+/** The default month names to use if Intl API is not available. */
+export const DEFAULT_MONTH_NAMES = {
+    long: [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+    ],
+    short: [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec'
+    ],
+    narrow: ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D']
+};
+
+/** The default day of the week names to use if Intl API is not available. */
+export const DEFAULT_DAY_OF_WEEK_NAMES = {
+    long: [
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday'
+    ],
+    short: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    narrow: ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+};
+
+/** The default date names to use if Intl API is not available. */
+export const DEFAULT_DATE_NAMES = range(31, i => String(i + 1));

--- a/projects/picker/src/lib/utils/date.utils.ts
+++ b/projects/picker/src/lib/utils/date.utils.ts
@@ -1,0 +1,97 @@
+/**
+ * date.utils
+ */
+
+/**
+ * Creates a date with the given year, month, date, hour, minute and second. Does not allow over/under-flow of the
+ * month and date.
+ */
+export function createDate(
+    year: number,
+    month: number,
+    date: number,
+    hours: number = 0,
+    minutes: number = 0,
+    seconds: number = 0
+): Date {
+    if (month < 0 || month > 11) {
+        throw Error(
+            `Invalid month index "${month}". Month index has to be between 0 and 11.`
+        );
+    }
+
+    if (date < 1) {
+        throw Error(
+            `Invalid date "${date}". Date has to be greater than 0.`
+        );
+    }
+
+    if (hours < 0 || hours > 23) {
+        throw Error(
+            `Invalid hours "${hours}". Hours has to be between 0 and 23.`
+        );
+    }
+
+    if (minutes < 0 || minutes > 59) {
+        throw Error(
+            `Invalid minutes "${minutes}". Minutes has to between 0 and 59.`
+        );
+    }
+
+    if (seconds < 0 || seconds > 59) {
+        throw Error(
+            `Invalid seconds "${seconds}". Seconds has to be between 0 and 59.`
+        );
+    }
+
+    const result = createDateWithOverflow(
+        year,
+        month,
+        date,
+        hours,
+        minutes,
+        seconds
+    );
+
+    // Check that the date wasn't above the upper bound for the month, causing the month to overflow
+    // For example, createDate(2017, 1, 31) would try to create a date 2017/02/31 which is invalid
+    if (result.getMonth() !== month) {
+        throw Error(
+            `Invalid date "${date}" for month with index "${month}".`
+        );
+    }
+
+    return result;
+}
+
+/**
+ * Gets the number of days in the month of the given date.
+ */
+export function getNumDaysInMonth(date: Date): number {
+    const lastDateOfMonth = createDateWithOverflow(
+        date.getFullYear(),
+        date.getMonth() + 1,
+        0
+    );
+
+    return lastDateOfMonth.getDate();
+}
+
+/**
+ * Creates a date but allows the month and date to overflow.
+ */
+function createDateWithOverflow(
+    year: number,
+    month: number,
+    date: number,
+    hours: number = 0,
+    minutes: number = 0,
+    seconds: number = 0
+): Date {
+    const result = new Date(year, month, date, hours, minutes, seconds);
+
+    if (year >= 0 && year < 100) {
+        result.setFullYear(result.getFullYear() - 1900);
+    }
+    return result;
+}


### PR DESCRIPTION
Creates a new DateTimeAdapter implementation which uses unix timestamps (the number of milliseconds that have elapsed since January 1, 1970) in the form of `number` as NgModel value type.
    
Also moves some constants and utility methods in native-date-time-adapter to a common place since this adapter's implementation is very similar to native-date-time-adapter.
    
Further performance improvements may be done in the future.
Some of the methods contain multiple date-number conversions.
