### PR TITLE
Allow Angular locale data to be missing when computing first day of week

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@danielmoncada/angular-datetime-picker",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Angular Date Time Picker",
   "keywords": [
     "Angular",

--- a/projects/picker/package.json
+++ b/projects/picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Angular Date Time Picker",
   "keywords": [
     "Angular",

--- a/projects/picker/src/lib/date-time/calendar-month-view.component.spec.ts
+++ b/projects/picker/src/lib/date-time/calendar-month-view.component.spec.ts
@@ -1,6 +1,9 @@
 /**
  * calendar-month-view.component.spec
  */
+import { registerLocaleData } from '@angular/common';
+import localeDutch from '@angular/common/locales/nl';
+import { DateTimeAdapter } from './adapter/date-time-adapter.class';
 import { OwlMonthViewComponent } from './calendar-month-view.component';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { OwlDateTimeIntl } from './date-time-picker-intl.service';
@@ -295,6 +298,68 @@ describe('OwlMonthViewComponent', () => {
             expect(cellTwo.classList).not.toContain(
                 'owl-dt-calendar-cell-disabled'
             );
+        });
+    });
+
+
+    describe('standard month view (locale tests)', () => {
+        let fixture: ComponentFixture<StandardMonthViewComponent>;
+        let adapter: DateTimeAdapter<unknown>;
+        let monthViewDebugElement: DebugElement;
+        let monthViewElement: HTMLElement;
+        let monthViewInstance: OwlMonthViewComponent<Date>;
+
+        beforeAll(() => {
+            registerLocaleData(localeDutch);
+        });
+
+        beforeEach(() => {
+            fixture = TestBed.createComponent(StandardMonthViewComponent);
+
+            adapter = TestBed.inject(DateTimeAdapter);
+            monthViewDebugElement = fixture.debugElement.query(
+                By.directive(OwlMonthViewComponent)
+            );
+            monthViewElement = monthViewDebugElement.nativeElement;
+            monthViewInstance = monthViewDebugElement.componentInstance;
+        });
+
+        it('should derive the first day of the week based on the active locale', () => {
+            adapter.setLocale('nl-NL');
+
+            fixture.detectChanges();
+            const weekdayCells = monthViewElement.querySelectorAll(
+                '.owl-dt-weekday'
+            );
+            expect(weekdayCells[0].getAttribute('aria-label')).toBe('maandag');
+        });
+
+        it('should fallback to Sunday as first day of the week when when locale data is missing', () => {
+            adapter.setLocale('unknown');
+
+            fixture.detectChanges();
+            const weekdayCells = monthViewElement.querySelectorAll(
+                '.owl-dt-weekday'
+            );
+            expect(weekdayCells[0].getAttribute('aria-label')).toBe('Sunday');
+        });
+
+        it('should update the default day of the week when locale changes', () => {
+            adapter.setLocale('nl-NL');
+
+            fixture.detectChanges();
+            const weekdayCellsNl = monthViewElement.querySelectorAll(
+                '.owl-dt-weekday'
+            );
+            expect(weekdayCellsNl[0].getAttribute('aria-label')).toBe('maandag');
+
+            adapter.setLocale('en-US');
+
+            fixture.detectChanges();
+            const weekdayCellsUs = monthViewElement.querySelectorAll(
+                '.owl-dt-weekday'
+            );
+            expect(weekdayCellsUs[0].getAttribute('aria-label')).toBe('Sunday');
         });
     });
 });

--- a/projects/picker/src/lib/date-time/calendar-month-view.component.ts
+++ b/projects/picker/src/lib/date-time/calendar-month-view.component.ts
@@ -68,9 +68,8 @@ export class OwlMonthViewComponent<T>
      * Define the first day of a week
      * Sunday: 0 - Saturday: 6
      * */
-    private _firstDayOfWeek = getLocaleFirstDayOfWeek(
-        this.dateTimeAdapter.getLocale()
-    );
+    private _firstDayOfWeek: number;
+
     @Input()
     get firstDayOfWeek(): number {
         return this._firstDayOfWeek;
@@ -300,15 +299,14 @@ export class OwlMonthViewComponent<T>
     ) {}
 
     public ngOnInit() {
+        this.updateFirstDayOfWeek(this.dateTimeAdapter.getLocale());
         this.generateWeekDays();
 
         this.localeSub = this.dateTimeAdapter.localeChanges.subscribe(
             locale => {
+                this.updateFirstDayOfWeek(locale);
                 this.generateWeekDays();
                 this.generateCalendar();
-                this.firstDayOfWeek = this.isDefaultFirstDayOfWeek
-                    ? getLocaleFirstDayOfWeek(locale)
-                    : this.firstDayOfWeek;
                 this.cdRef.markForCheck();
             }
         );
@@ -531,6 +529,16 @@ export class OwlMonthViewComponent<T>
         }
 
         this.setSelectedDates();
+    }
+
+    private updateFirstDayOfWeek(locale: string): void {
+        if (this.isDefaultFirstDayOfWeek) {
+            try {
+                this._firstDayOfWeek = getLocaleFirstDayOfWeek(locale);
+            } catch {
+                this._firstDayOfWeek = 0;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
In 407a7f8623f2ee42251e94415f9a2d382ea99b9a the first day of the week would
be automatically computed from the current locale, based on Angular's locale
data. This would throw an error when the locale data is missing, causing the
calender view to be completely empty.

Additionally, this fixes a subtle bug where changing the locale multiple
times would only recompute the first day of the week during the first locale
change, not any subsequent ones.

Fixes #110