### PR TITLE
Don't reformat input while field is focused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # dependencies
 /node_modules
+/projects/picker/node_modules
 
 # IDEs and editors
 /.idea

--- a/projects/picker/src/lib/date-time/timer-box.component.html
+++ b/projects/picker/src/lib/date-time/timer-box.component.html
@@ -19,10 +19,11 @@
 </button>
 <label class="owl-dt-timer-content">
     <input class="owl-dt-timer-input" maxlength="2"
-           [value]="displayValue | numberFixedLen : 2"
+           [value]="displayValue"
            (keydown.arrowup)="!upBtnDisabled && upBtnClicked()"
            (keydown.arrowdown)="!downBtnDisabled && downBtnClicked()"
-           (input)="handleInputChange(valueInput.value)" 
+           (input)="handleInputChange(valueInput.value)"
+           (focusin)="focusIn()"
            (focusout)="focusOut(valueInput.value)"
            #valueInput>
     <span class="owl-hidden-accessible">{{inputLabel}}</span>

--- a/projects/picker/src/lib/date-time/timer-box.component.ts
+++ b/projects/picker/src/lib/date-time/timer-box.component.ts
@@ -15,7 +15,6 @@ import {
 } from '@angular/core';
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Subject, Subscription } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
 
 @Component({
     exportAs: 'owlDateTimeTimerBox',
@@ -65,8 +64,21 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
 
     private inputStreamSub = Subscription.EMPTY;
 
-    get displayValue(): number {
-        return this.boxValue || this.value;
+    private hasFocus = false;
+
+    get displayValue(): string {
+        if (this.hasFocus) {
+            // Don't try to reformat the value that user is currently editing
+            return this.valueInput.nativeElement.value;
+        }
+
+        const value = this.boxValue || this.value;
+
+        if (value === null || isNaN(value)) {
+            return '';
+        }
+
+        return value < 10 ? '0' + value.toString() : value.toString();
     }
 
     get owlDTTimerBoxClass(): boolean {
@@ -74,16 +86,14 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
     }
 
     @ViewChild('valueInput', { static: true })
-    private valueInput: ElementRef;
+    private valueInput: ElementRef<HTMLInputElement>;
     private onValueInputMouseWheelBind = this.onValueInputMouseWheel.bind(this);
 
     constructor() {
     }
 
     public ngOnInit() {
-        this.inputStreamSub = this.inputStream.pipe(
-            debounceTime(500)
-        ).subscribe(( val: string ) => {
+        this.inputStreamSub = this.inputStream.subscribe(( val: string ) => {
             if (val) {
                 const inputValue = coerceNumberProperty(val, 0);
                 this.updateValueViaInput(inputValue);
@@ -91,7 +101,7 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
         });
         this.bindValueInputMouseWheel();
     }
-        
+
     public ngOnDestroy(): void {
         this.unbindValueInputMouseWheel();
         this.inputStreamSub.unsubscribe();
@@ -109,7 +119,12 @@ export class OwlTimerBoxComponent implements OnInit, OnDestroy {
         this.inputStream.next(val);
     }
 
+    public focusIn(): void {
+        this.hasFocus = true;
+    }
+
     public focusOut(value: string): void {
+        this.hasFocus = false;
         if (value) {
             const inputValue = coerceNumberProperty(value, 0);
             this.updateValueViaInput(inputValue);

--- a/projects/picker/src/lib/date-time/timer.component.spec.ts
+++ b/projects/picker/src/lib/date-time/timer.component.spec.ts
@@ -16,6 +16,7 @@ import { OwlNativeDateTimeModule } from './adapter/native-date-time.module';
 import { OwlDateTimeModule } from './date-time.module';
 import { By } from '@angular/platform-browser';
 import { OwlTimerComponent } from './timer.component';
+import { dispatchFakeEvent } from '../../test-helpers';
 
 const JAN = 0,
     FEB = 1,
@@ -343,6 +344,22 @@ describe('OwlTimerComponent', () => {
             expect(arrowBtns[3].hasAttribute('disabled')).toBe(false);
             expect(arrowBtns[5].hasAttribute('disabled')).toBe(false);
         });
+
+        it('should not reformat input text while field is focused', fakeAsync(() => {
+            const timeCells = timerElement.querySelectorAll<HTMLInputElement>('.owl-dt-timer-input');
+
+            dispatchFakeEvent(timeCells[0], 'focusin');
+            timeCells[0].value = '5';
+            dispatchFakeEvent(timeCells[0], 'input');
+
+            timeCells[1].value = '8';
+            dispatchFakeEvent(timeCells[1], 'input');
+
+            fixture.detectChanges();
+
+            expect(timeCells[0].value).toEqual('5');
+            expect(timeCells[1].value).toEqual('08');
+        }));
     });
 });
 


### PR DESCRIPTION
Never normalize the input value for field while it is focused, but do it immediately upon losing focus.

Previously code for handling input had a 500 ms debounce so that if user was fast enough, they could type '17' in the field. If the 500 ms passed between 1 and 7, then the text would change to '01' in the middle of typing and the keystroke for 7 would be lost, confusing the user.

Related problem with the old debounce implementation was that the value was not visible outside the component before 500 ms had passed. If user typed a value and the immediately closed the dialog, the value would be lost.