### PR TITLE
select only to-date in rangeMode

### DIFF
--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
@@ -64,7 +64,7 @@ export class OwlDateTimeContainerComponent<T>
     // retain start and end time
     private retainStartTime: T;
     private retainEndTime: T;
-    
+
     /**
      * Stream emits when try to hide picker
      * */
@@ -417,16 +417,20 @@ export class OwlDateTimeContainerComponent<T>
             return null;
         }
 
-        // if the given calendar day is after or equal to 'from',
-        // set ths given date as 'to'
+        // if the given calendar day is after or equal to 'from' or this is the first selected date but activeSelectedIndex was set by user
+        // set the given date as 'to'
         // otherwise, set it as 'from' and set 'to' to null
         if (this.picker.selectMode === 'range') {
             if (
-                this.picker.selecteds &&
-                this.picker.selecteds.length &&
-                !to &&
-                from &&
-                this.dateTimeAdapter.differenceInCalendarDays(result, from) >= 0
+                (this.picker.selecteds &&
+                    this.picker.selecteds.length &&
+                    !to &&
+                    from &&
+                    this.dateTimeAdapter.differenceInCalendarDays(
+                        result,
+                        from
+                    ) >= 0) ||
+                (!to && !from && this.activeSelectedIndex === 1)
             ) {
                 if (this.picker.endAt && !this.retainEndTime) {
                     to = this.dateTimeAdapter.createDate(


### PR DESCRIPTION
In my project I need to have the ability to only select a to-date if using a range. Before this commit, if a user 
1. opened the empty dialog
2. selected to
3. clicked a date
it would switch to a from-date, which seems weird. Now it would be possible to leave the from-date blank.
