### PR TITLE
Replace deprecated angular  PortalInjector with Injector.create

### DIFF
--- a/projects/picker/src/lib/dialog/dialog.service.ts
+++ b/projects/picker/src/lib/dialog/dialog.service.ts
@@ -29,7 +29,6 @@ import {
 import {
     ComponentPortal,
     ComponentType,
-    PortalInjector
 } from '@angular/cdk/portal';
 
 export const OWL_DIALOG_DATA = new InjectionToken<any>('OwlDialogData');
@@ -234,19 +233,17 @@ export class OwlDialogService {
         dialogContainer: OwlDialogContainerComponent
     ) {
         const userInjector =
-            config &&
-            config.viewContainerRef &&
-            config.viewContainerRef.injector;
-        const injectionTokens = new WeakMap();
+            config?.viewContainerRef?.injector;
+        const providers = [
+            { provide: OwlDialogRef, useValue: dialogRef },
+            { provide: OwlDialogContainerComponent, useValue: dialogContainer },
+            { provide: OWL_DIALOG_DATA, useValue: config?.data },
+        ];
 
-        injectionTokens.set(OwlDialogRef, dialogRef);
-        injectionTokens.set(OwlDialogContainerComponent, dialogContainer);
-        injectionTokens.set(OWL_DIALOG_DATA, config.data);
-
-        return new PortalInjector(
-            userInjector || this.injector,
-            injectionTokens
-        );
+        return Injector.create({
+            providers,
+            parent: userInjector || this.injector,
+        });
     }
 
     private createOverlay(config: OwlDialogConfigInterface): OverlayRef {


### PR DESCRIPTION
PortalInjector (@angular/cdk/portal) had been deprecated long time ago and is removed in Angular 20.0.0-rc.1